### PR TITLE
Content-Length takes emoji's into account

### DIFF
--- a/__tests__/jsonRpcEndpoint.test.ts
+++ b/__tests__/jsonRpcEndpoint.test.ts
@@ -72,6 +72,22 @@ describe('JSONRPCEndpoint', () => {
         expect(mockWriteStream.buffer()).toBe(`Content-Length: ${JSON.stringify(jsonRpcMessage).length}\r\n\r\n${JSON.stringify(jsonRpcMessage)}`);
     });
 
+    it('sends a JSONRPC notification with emojis payload', async () => {
+        const mockWriteStream: WriteMemory = new WriteMemory();
+        const e: JSONRPCEndpoint = new JSONRPCEndpoint(mockWriteStream, mockReadStreamOK([], true));
+
+        const message = { param1: 'value1😀', param2: { subParam1: 'subValue1🎉' } };
+
+        e.notify('someMethod', message);
+
+        const jsonRpcMessage: JSONRPCRequest = { "jsonrpc": "2.0", "method": "someMethod", "params": message };
+
+        // Calculate byte size instead of character size to account for emojis
+        const byteSize = Buffer.byteLength(JSON.stringify(jsonRpcMessage), 'utf8');
+
+        expect(mockWriteStream.buffer()).toBe(`Content-Length: ${byteSize}\r\n\r\n${JSON.stringify(jsonRpcMessage)}`);
+    });
+
     it('sends a JSONRPC request with the matched response', async () => {
         const mockWriteStream: WriteMemory = new WriteMemory();
         const mockReadStream: Readable = mockReadStreamOK([], false);

--- a/src/jsonRpcEndpoint.ts
+++ b/src/jsonRpcEndpoint.ts
@@ -23,7 +23,8 @@ export class JSONRPCEndpoint extends EventEmitter {
         this.client = new JSONRPCClient(async (jsonRPCRequest) => {
             const jsonRPCRequestStr = JSON.stringify(jsonRPCRequest);
             Logger.log(`sending: ${jsonRPCRequestStr}`, LoggerLevel.DEBUG);
-            this.writable.write(`Content-Length: ${jsonRPCRequestStr.length}\r\n\r\n${jsonRPCRequestStr}`);
+            const contentLength = Buffer.from(jsonRPCRequestStr, 'utf-8').byteLength;
+            this.writable.write(`Content-Length: ${contentLength}\r\n\r\n${jsonRPCRequestStr}`);
         }, createId);
 
         this.readableByline.on('data', (jsonRPCResponseOrRequest: string) => {


### PR DESCRIPTION
When the payload contains emoji's this would result in incorrect Content-Lengths, this can be resolved by getting the byteLength instead